### PR TITLE
update call to run_build->run in deploy target to reflect recent refactoring/rename of the method

### DIFF
--- a/potr
+++ b/potr
@@ -298,7 +298,7 @@ fi
 if [ $1 == "deploy" ]
 then
     # Build the code
-    run_build
+    run
     if [ $? -ne 0 ]
     then
         # If the build command failed, then exit


### PR DESCRIPTION
I noticed last night that the ./potr deploy command was broken on HEAD. I will also apply to monorepo potr.